### PR TITLE
fix(#1): disable hotkeys while input field is focused

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,21 @@ const downloadButton = document.querySelector("#image-download-link a");
 const returnToSearchPageLink = document.querySelector(".search-name a");
 const searchBar = document.querySelector("#tags");
 
+const commandSilencingElements = [
+  HTMLInputElement,
+  HTMLTextAreaElement,
+];
+
+function shouldSilenceCommands () {
+  return commandSilencingElements.some(element => {
+    return document.activeElement instanceof element;
+  });
+}
+
 function addHotkeyListener(key, fn) {
   document.addEventListener("keydown", (event) => {
     if (event.repeat) return;
+    if (shouldSilenceCommands()) return;
     if (event.key === key) {
       fn();
     }

--- a/index.js
+++ b/index.js
@@ -22,16 +22,20 @@ const commandSilencingElements = [
   HTMLTextAreaElement,
 ];
 
-function shouldSilenceCommands () {
-  return commandSilencingElements.some(element => {
-    return document.activeElement instanceof element;
-  });
+function shouldSilenceCommands(event) {
+  if (event.repeat) return true;
+  if (document.activeElement) {
+    return commandSilencingElements.some(element => {
+      return document.activeElement instanceof element;
+    });
+  } else {
+    return false;
+  }
 }
 
 function addHotkeyListener(key, fn) {
   document.addEventListener("keydown", (event) => {
-    if (event.repeat) return;
-    if (shouldSilenceCommands()) return;
+    if (shouldSilenceCommands(event)) return;
     if (event.key === key) {
       fn();
     }


### PR DESCRIPTION
Added a check for the currently focused element. Should capture inputs for search + textarea for comment box.

![2023-01-01 21 21 38](https://user-images.githubusercontent.com/83324179/210191222-2abcd2b8-6316-4365-9584-3c4e81ff3576.gif)

Closes #1